### PR TITLE
add template key in admin overwiev

### DIFF
--- a/classes/templateadmintools.php
+++ b/classes/templateadmintools.php
@@ -46,7 +46,7 @@ class templateadmintools {
                 get_string('version'),
                 get_string('description')
         );
-        $table->headspan = array(1, 1, 1);
+        $table->headspan = array(1, 1, 1, 1);
         $table->colclasses = array(
                 'templatenamecol', 'templatekeycol', 'templateversioncol', 'templateinstructionscol'
         );

--- a/classes/templateadmintools.php
+++ b/classes/templateadmintools.php
@@ -58,6 +58,9 @@ class templateadmintools {
             $titlelink = $editlink = \html_writer::link($item->url, $item->title);
             $titlecell = new \html_table_cell($titlelink);
 
+            // templatekey cell
+            $templatekeycell = new \html_table_cell($item->templatekey);
+            
             //version cell
             $updateversion = presets_control::template_has_update($item->index);
             if ($updateversion) {
@@ -75,7 +78,7 @@ class templateadmintools {
             $instructionscell = new \html_table_cell($item->instructions);
 
             $row->cells = array(
-                    $titlecell, $versioncell, $instructionscell
+                    $titlecell, $templatekeycell, $versioncell, $instructionscell
             );
             $table->data[] = $row;
         }

--- a/classes/templateadmintools.php
+++ b/classes/templateadmintools.php
@@ -42,7 +42,7 @@ class templateadmintools {
         $table->id = 'filter_generico_template_list';
         $table->head = array(
                 get_string('name'),
-                get_string('templatekey'),
+                get_string('key', 'filter_generico'),
                 get_string('version'),
                 get_string('description')
         );
@@ -134,6 +134,12 @@ class templateadmintools {
             $template_details = new \stdClass();
             $template_details->index = $tindex;
             $template_details->title = $template_title;
+
+            if ($conf && property_exists($conf, 'templatekey_' . $tindex)) {
+                $template_details->templatekey = $conf->{'templatekey_' . $tindex};;
+            } else {
+                $template_details->templatekey = '';
+            }
 
             $template_details->version = "";
             if (property_exists($conf, 'templateversion_' . $tindex)) {

--- a/classes/templateadmintools.php
+++ b/classes/templateadmintools.php
@@ -42,12 +42,13 @@ class templateadmintools {
         $table->id = 'filter_generico_template_list';
         $table->head = array(
                 get_string('name'),
+                get_string('templatekey'),
                 get_string('version'),
                 get_string('description')
         );
         $table->headspan = array(1, 1, 1);
         $table->colclasses = array(
-                'templatenamecol', 'templateversioncol', 'templateinstructionscol'
+                'templatenamecol', 'templatekeycol', 'templateversioncol', 'templateinstructionscol'
         );
 
         //loop through templates and add to table

--- a/lang/en/filter_generico.php
+++ b/lang/en/filter_generico.php
@@ -39,6 +39,7 @@ $string['template'] = 'The body of template {$a}';
 $string['template_desc'] = 'Put the template here, define variables by surrounding them with @@ marks at either e. eg @@variable@@';
 $string['templatekey'] = 'The key that identifies template {$a}';
 $string['templatekey_desc'] = 'The key should be one word and only contain numbers and letters, underscores, hyphens and dots .';
+$string['key'] = 'Template key';
 $string['templatename'] = 'Template Name';
 $string['templatename_desc'] = 'The name of this template.';
 $string['templateinstructions'] = 'Instructions (template {$a})';


### PR DESCRIPTION
solves https://github.com/justinhunt/moodle-filter_generico/issues/51 partially.
adds a row in the admin settings to see the template key in the overview of all templates. this makes finding the correct template to edit easier.