### PR TITLE
Sort presets menu

### DIFF
--- a/classes/presets_control.php
+++ b/classes/presets_control.php
@@ -192,6 +192,10 @@ class presets_control extends \admin_setting {
                 }
             }
         }
+        uasort(
+            $ret,
+            fn($a, $b) => strnatcasecmp($a['name'], $b['name'])
+        );
         return $ret;
     }// End of fetch presets function.
 


### PR DESCRIPTION
The templates menu lists the presets in the order they're returned by PHP's `DirectoryIterator`, which is basically random. Sorting them alphabetically by name makes them a little bit easier to locate.