### PR TITLE
#68 - Fixes JS/CSS display after first browser login

### DIFF
--- a/genericocss.php
+++ b/genericocss.php
@@ -27,8 +27,6 @@
 require_once(dirname(dirname(dirname(__FILE__))) . '/config.php');
 require_once(dirname(__FILE__) . '/lib.php');
 
-require_login();
-
 $tindex = required_param('t', PARAM_TEXT);
 
 $conf = get_config('filter_generico');

--- a/genericojs.php
+++ b/genericojs.php
@@ -26,8 +26,6 @@
 
 require_once(dirname(dirname(dirname(__FILE__))) . '/config.php');
 
-require_login();
-
 $tindex = required_param('t', PARAM_TEXT);
 $generator = new \filter_generico\template_script_generator($tindex);
 $templatescript = $generator->get_template_script();


### PR DESCRIPTION
Fixes #68.

Removing the require_login() does the trick. Of course if you need those in there somehow, you have to do it differently.